### PR TITLE
Fix '/rep all' to preserve wool data/damage/durability.

### DIFF
--- a/src/com/mrockey28/bukkit/ItemRepair/Repair.java
+++ b/src/com/mrockey28/bukkit/ItemRepair/Repair.java
@@ -38,7 +38,7 @@ public class Repair extends AutoRepairSupport{
 		
 		for (ItemStack item : player.getInventory().getContents())
 		{
-			if (item == null || item.getType() == Material.AIR)
+			if (item == null || item.getType() == Material.AIR || item.getType() == Material.WOOL)
 			{
 				continue;
 			}


### PR DESCRIPTION
Adds a check to prevent the repairAll() function from attempting to repair the ItemStack if it's wool.
